### PR TITLE
Register multiple db configurations and establish connections

### DIFF
--- a/src/MultiDb.Extensions/MultiDb.Extensions.csproj
+++ b/src/MultiDb.Extensions/MultiDb.Extensions.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <!-- NuGet metadata -->
+    <PackageId>MultiDb.Extensions</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>YourCompany</Authors>
+    <Company>YourCompany</Company>
+    <Description>Extension method to register multiple database configurations and auto-establish connections on startup for .NET.</Description>
+    <RepositoryUrl>https://example.com/your-repo</RepositoryUrl>
+    <PackageTags>database;connection;multi-db;dependency-injection;hosting;options</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://example.com/your-repo</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+  </ItemGroup>
+
+  <!-- No direct provider dependencies to keep the package lightweight. -->
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+</Project>
+

--- a/src/MultiDb.Extensions/README.md
+++ b/src/MultiDb.Extensions/README.md
@@ -1,0 +1,89 @@
+# MultiDb.Extensions
+
+Register multiple database configurations with a single extension method, and optionally warm up connections on startup.
+
+## Install
+
+```bash
+dotnet add package MultiDb.Extensions
+```
+
+## Configure
+
+appsettings.json:
+
+```json
+{
+  "MultiDb": {
+    "Databases": [
+      {
+        "Name": "Primary",
+        "Provider": "SqlServer",
+        "ConnectionString": "Server=.;Database=App;Trusted_Connection=True;TrustServerCertificate=True",
+        "WarmupOnStart": true
+      },
+      {
+        "Name": "Reporting",
+        "Provider": "PostgreSql",
+        "ConnectionString": "Host=localhost;Username=postgres;Password=postgres;Database=reporting",
+        "WarmupOnStart": false
+      }
+    ]
+  }
+}
+```
+
+Program.cs:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+// Bind from configuration and warmup on start
+builder.Services.AddMultiDb(builder.Configuration, addWarmupHostedService: true);
+
+var app = builder.Build();
+app.Run();
+```
+
+Or configure in code:
+
+```csharp
+builder.Services.AddMultiDb(configureOptions: options =>
+{
+    options.Databases.Add(new DatabaseConfig
+    {
+        Name = "Primary",
+        Provider = "Npgsql",
+        ConnectionString = builder.Configuration.GetConnectionString("Primary")!
+    });
+});
+```
+
+## Usage
+
+```csharp
+public sealed class MyRepository(IMultiDbConnectionFactory factory)
+{
+    public async Task<int> GetCountAsync(CancellationToken ct)
+    {
+        await using var conn = factory.CreateConnection("Primary");
+        await conn.OpenAsync(ct);
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT 1";
+        var result = await cmd.ExecuteScalarAsync(ct);
+        return Convert.ToInt32(result);
+    }
+}
+```
+
+Note: Ensure your app references relevant ADO.NET providers: `Npgsql`, `Microsoft.Data.SqlClient`, `MySql.Data`, `Microsoft.Data.Sqlite`.
+
+## Pack / Publish
+
+```bash
+dotnet pack -c Release /p:PackageVersion=1.0.0
+# then push
+# dotnet nuget push ./bin/Release/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
+```
+
+License: MIT

--- a/src/MultiDb.Extensions/src/Abstractions/IMultiDbConnectionFactory.cs
+++ b/src/MultiDb.Extensions/src/Abstractions/IMultiDbConnectionFactory.cs
@@ -1,0 +1,10 @@
+using System.Data.Common;
+
+namespace MultiDb.Extensions.Abstractions
+{
+    public interface IMultiDbConnectionFactory
+    {
+        DbConnection CreateConnection(string databaseName);
+    }
+}
+

--- a/src/MultiDb.Extensions/src/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MultiDb.Extensions/src/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,59 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using MultiDb.Extensions.Abstractions;
+using MultiDb.Extensions.Hosting;
+using MultiDb.Extensions.Options;
+using MultiDb.Extensions.Services;
+
+namespace MultiDb.Extensions
+{
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers multi-database options and services. Supports configuration binding and optional warmup.
+        /// Expected configuration section: "MultiDb".
+        /// </summary>
+        /// <param name="services">The DI service collection.</param>
+        /// <param name="configuration">Optional configuration root; if provided, binds options from section "MultiDb".</param>
+        /// <param name="configureOptions">Optional delegate to configure options in code.</param>
+        /// <param name="addWarmupHostedService">If true, adds a hosted service to open warm connections on startup.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection AddMultiDb(this IServiceCollection services,
+            IConfiguration? configuration = null,
+            Action<MultiDbOptions>? configureOptions = null,
+            bool addWarmupHostedService = true)
+        {
+            if (services == null) throw new ArgumentNullException(nameof(services));
+
+            if (configuration is not null)
+            {
+                services.AddOptions<MultiDbOptions>()
+                    .Bind(configuration.GetSection(MultiDbOptions.SectionName))
+                    .Validate(options => options is not null, "MultiDb options must be provided.")
+                    .ValidateOnStart();
+            }
+            else
+            {
+                services.AddOptions<MultiDbOptions>();
+            }
+
+            if (configureOptions is not null)
+            {
+                services.Configure(configureOptions);
+            }
+
+            services.AddSingleton<IMultiDbConnectionFactory, MultiDbConnectionFactory>();
+
+            if (addWarmupHostedService)
+            {
+                services.AddHostedService<MultiDbWarmupHostedService>();
+            }
+
+            return services;
+        }
+    }
+}
+

--- a/src/MultiDb.Extensions/src/Hosting/MultiDbWarmupHostedService.cs
+++ b/src/MultiDb.Extensions/src/Hosting/MultiDbWarmupHostedService.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiDb.Extensions.Abstractions;
+using MultiDb.Extensions.Options;
+
+namespace MultiDb.Extensions.Hosting
+{
+    internal sealed class MultiDbWarmupHostedService : IHostedService
+    {
+        private readonly ILogger<MultiDbWarmupHostedService> _logger;
+        private readonly IMultiDbConnectionFactory _connectionFactory;
+        private readonly IOptions<MultiDbOptions> _options;
+
+        public MultiDbWarmupHostedService(
+            ILogger<MultiDbWarmupHostedService> logger,
+            IMultiDbConnectionFactory connectionFactory,
+            IOptions<MultiDbOptions> options)
+        {
+            _logger = logger;
+            _connectionFactory = connectionFactory;
+            _options = options;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            var configs = _options.Value?.Databases;
+            if (configs is null)
+            {
+                return;
+            }
+
+            foreach (var cfg in configs)
+            {
+                if (!cfg.WarmupOnStart)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    using var connection = _connectionFactory.CreateConnection(cfg.Name);
+                    await OpenQuietlyAsync(connection, cancellationToken);
+                    _logger.LogInformation("Warm connection established for database '{DatabaseName}'.", cfg.Name);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Warm connection failed for database '{DatabaseName}'.", cfg.Name);
+                }
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        private static async Task OpenQuietlyAsync(DbConnection connection, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Let caller decide logging; swallow to avoid failing app startup.
+            }
+        }
+    }
+}
+

--- a/src/MultiDb.Extensions/src/Options/MultiDbOptions.cs
+++ b/src/MultiDb.Extensions/src/Options/MultiDbOptions.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace MultiDb.Extensions.Options
+{
+    public sealed class MultiDbOptions
+    {
+        public const string SectionName = "MultiDb";
+
+        public IList<DatabaseConfig> Databases { get; init; } = new List<DatabaseConfig>();
+    }
+
+    public sealed class DatabaseConfig
+    {
+        public string Name { get; init; } = string.Empty;
+
+        // e.g. "SqlServer", "PostgreSql", "MySql", "Sqlite".
+        public string Provider { get; init; } = string.Empty;
+
+        public string ConnectionString { get; init; } = string.Empty;
+
+        // Optional: whether to open a warm connection on startup
+        public bool WarmupOnStart { get; init; } = true;
+    }
+}
+

--- a/src/MultiDb.Extensions/src/Services/MultiDbConnectionFactory.cs
+++ b/src/MultiDb.Extensions/src/Services/MultiDbConnectionFactory.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiDb.Extensions.Abstractions;
+using MultiDb.Extensions.Options;
+
+namespace MultiDb.Extensions.Services
+{
+    public sealed class MultiDbConnectionFactory : IMultiDbConnectionFactory
+    {
+        private readonly ILogger<MultiDbConnectionFactory> _logger;
+        private readonly IReadOnlyDictionary<string, DatabaseConfig> _databaseConfigsByName;
+
+        public MultiDbConnectionFactory(
+            IOptions<MultiDbOptions> options,
+            ILogger<MultiDbConnectionFactory> logger)
+        {
+            _logger = logger;
+            var configs = options.Value?.Databases ?? new List<DatabaseConfig>();
+            _databaseConfigsByName = configs.ToDictionary(
+                keySelector: c => c.Name,
+                elementSelector: c => c,
+                comparer: StringComparer.OrdinalIgnoreCase);
+        }
+
+        public DbConnection CreateConnection(string databaseName)
+        {
+            if (string.IsNullOrWhiteSpace(databaseName))
+            {
+                throw new ArgumentException("Database name must be provided", nameof(databaseName));
+            }
+
+            if (!_databaseConfigsByName.TryGetValue(databaseName, out var config))
+            {
+                throw new InvalidOperationException($"No database configuration was found for '{databaseName}'.");
+            }
+
+            var provider = config.Provider?.Trim();
+            if (string.IsNullOrWhiteSpace(provider))
+            {
+                throw new InvalidOperationException($"Database '{databaseName}' has no provider configured.");
+            }
+
+            var connectionString = config.ConnectionString;
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new InvalidOperationException($"Database '{databaseName}' has an empty connection string.");
+            }
+
+            var connection = CreateProviderConnection(provider, connectionString);
+            return connection ?? throw new NotSupportedException($"Provider '{provider}' is not supported.");
+        }
+
+        private DbConnection? CreateProviderConnection(string provider, string connectionString)
+        {
+            // Provider-specific implementations are dynamically located via DbProviderFactories when available.
+            // Consumers can ensure provider registrations are available by referencing provider packages.
+            try
+            {
+                // Try canonical invariant names first (e.g., Npgsql, MySql.Data.MySqlClient, System.Data.SqlClient, Microsoft.Data.SqlClient)
+                var invariantNamesToTry = provider switch
+                {
+                    "PostgreSql" or "Postgres" or "Npgsql" => new[] { "Npgsql" },
+                    "SqlServer" or "MSSQL" => new[] { "Microsoft.Data.SqlClient", "System.Data.SqlClient" },
+                    "MySql" => new[] { "MySql.Data.MySqlClient" },
+                    "Sqlite" or "SQLite" => new[] { "Microsoft.Data.Sqlite" },
+                    _ => new[] { provider }
+                };
+
+                foreach (var invariant in invariantNamesToTry)
+                {
+                    var factory = GetFactorySafe(invariant);
+                    if (factory is null)
+                    {
+                        continue;
+                    }
+                    var connection = factory.CreateConnection();
+                    if (connection is null)
+                    {
+                        continue;
+                    }
+                    connection.ConnectionString = connectionString;
+                    return connection;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create provider connection for provider '{Provider}'.", provider);
+            }
+
+            return null;
+        }
+
+        private static DbProviderFactory? GetFactorySafe(string providerInvariantName)
+        {
+            try
+            {
+                return DbProviderFactories.GetFactory(providerInvariantName);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Add a `MultiDb.Extensions` NuGet package with an extension method to register multiple database configurations and an optional hosted service to warm up connections on startup.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d96a172-c864-45ef-9a27-07a87c6aa59b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d96a172-c864-45ef-9a27-07a87c6aa59b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

